### PR TITLE
docs(openspec): plan phase 1 mvp control plane

### DIFF
--- a/openspec/changes/phase-1-mvp-control-plane-plan/.openspec.yaml
+++ b/openspec/changes/phase-1-mvp-control-plane-plan/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-29

--- a/openspec/changes/phase-1-mvp-control-plane-plan/design.md
+++ b/openspec/changes/phase-1-mvp-control-plane-plan/design.md
@@ -1,0 +1,134 @@
+# 设计
+
+## 设计目标
+
+本变更只冻结 Phase 1 MVP 控制面方案，后续具体文档更新、Issue 创建、FE/BE 修复都应按该方案拆分执行。
+
+核心原则：
+
+- 整个 `blog-Docs` 是控制面，不由单一目录或单一文档承担全部职责。
+- 固定层只写长期边界和阶段归属，运行态只写当前状态，验收层按阶段定义测试和证据。
+- Phase 1 面向 Agent 时必须足够明确：做什么、做到什么样、不做什么、验收看哪里、完成后回写哪里。
+
+## Phase 1 MVP 定义
+
+Phase 1 命名为：`MVP 最小内容闭环`。
+
+本阶段只交付“账号认证 + 文章读写”的最小博客闭环：
+
+- 用户可以通过邮箱验证码注册。
+- 用户可以登录并获得 JWT。
+- 登录用户可以创建、编辑、删除并发布文章。
+- 游客可以浏览已发布文章列表和文章详情。
+- 文章数据必须真实写入 PostgreSQL，并能通过前端再次读取。
+- FE 核心验收不得依赖 mock 数据。
+- OpenAPI、FE 调用、BE 返回必须逐步对齐。
+
+本阶段明确不做：
+
+- 评论、回复、点赞
+- TinyMCE 富文本编辑器
+- 图片上传、MinIO、OSS
+- 全文搜索
+- reCAPTCHA
+- 复杂个人中心，如头像上传、资料编辑、密码修改
+- 复杂后台 Dashboard 或统计面板
+- 完整 CI/CD、监控告警、E2E 自动化测试
+
+## 控制面文件职责
+
+### `docs/control-plane/`
+
+固定层，负责阶段边界和长期决策，不记录临时进度。
+
+- `phase-roadmap.md`
+  - 定义 Phase 0/1/2/3/4 的阶段目标和非目标。
+  - 说明原始 PRD 中的能力如何被安排到后续阶段。
+  - 防止 Agent 把后续阶段能力拉回 Phase 1。
+
+- `mvp-scope.md`
+  - 冻结 Phase 1 MVP 范围。
+  - 只写当前 MVP 必须做、明确不做、完成判定。
+  - 不写 Issue 状态、PR 进度、临时风险。
+
+### `docs/runtime/`
+
+运行层，负责当前阶段状态和回写面板，可高频更新。
+
+- `phase-current.md`
+  - 记录当前阶段是 Phase 1。
+  - 只放阶段摘要、当前状态、真源引用、任务包入口、回写规则入口。
+  - 不承载完整路线图、完整验收细则或 API 字段细节。
+
+- `issue-dispatch.md`
+  - 记录 Docs / FE / BE 待下发和已下发 Issue。
+  - 允许先记录 `planned` 状态，创建 Issue 后必须回写 URL。
+
+- `risk-register.md`
+  - 记录当前阶段风险、影响、缓解动作、触发条件和状态。
+
+- `openapi-gap-register.md`
+  - 记录 Phase 1 auth/articles 契约差异。
+  - 只作为后续契约修复任务输入，不直接改写正式 OpenAPI。
+
+### `docs/harness/`
+
+验收层，按阶段定义测试、CI/check 项、smoke 和证据要求。
+
+- `phase-1-mvp-harness.md`
+  - 定义 Phase 1 的 FE/BE 必跑命令。
+  - 定义认证和文章链路 smoke。
+  - 定义 PR 必须提交的证据形式。
+  - 明确哪些能力不作为 Phase 1 验收项。
+
+### `contracts/api/`
+
+契约层，继续以 `contracts/api/openapi.yaml` 作为 API 唯一真源。
+
+本变更只要求识别 auth/articles 相关差异，并把差异形成后续任务；完整契约大修应拆到后续 Issue 或后续 OpenSpec change。
+
+### `docs/workflow/`
+
+流程层，保留通用推进规则。
+
+- `task-release-and-sync-sop.md` 继续负责任务发布、Ready 门槛和同步节奏。
+- `progress-sync-protocol.md` 继续负责回写规则。
+- `spec-issue-test-flow.md` 继续负责 Spec -> Issue -> Test 主链路。
+
+### `docs/standards/`
+
+标准层，保留 AGENTS 和仓库接入标准。
+
+后续应根据本方案检查 FE/BE 的 AGENTS 接入状态，但本变更不直接修改 FE/BE AGENTS。
+
+## 后续 Issue 包建议
+
+### Docs Issue 包
+
+- `DOCS-P1-001`：冻结 Phase 1 MVP 范围和阶段路线图。
+- `DOCS-P1-002`：更新 Phase 1 runtime 面板。
+- `DOCS-P1-003`：建立 Phase 1 harness 文档。
+- `DOCS-P1-004`：识别 auth/articles OpenAPI 差异并形成后续契约任务。
+- `DOCS-P1-005`：对齐文档仓库入口与引用关系。
+
+### FE Issue 包
+
+- `FE-P1-001`：认证链路接入验收与证据补齐。
+- `FE-P1-002`：文章核心链路去 mock，统一真实 API 数据源。
+- `FE-P1-003`：FE AGENTS 接入控制面真源和阶段验收要求。
+
+### BE Issue 包
+
+- `BE-P1-001`：认证链路验收、关键测试和契约差异记录。
+- `BE-P1-002`：文章读写链路验收、权限测试和契约差异记录。
+- `BE-P1-003`：最小 harness/check 脚本或 CI gate 方案确认。
+
+## 回写要求
+
+后续 Issue 完成后必须按职责回写：
+
+- `docs/runtime/issue-dispatch.md`：更新 Issue / PR 链接和状态。
+- `docs/runtime/risk-register.md`：更新风险状态或新增风险。
+- `docs/runtime/openapi-gap-register.md`：更新 auth/articles 契约差异与后续处理入口。
+- `contracts/api/openapi.yaml`：仅当 API 行为已确认并进入契约任务时更新。
+- `docs/control-plane/mvp-scope.md`：只有范围边界变化时更新，且必须先走 OpenSpec。

--- a/openspec/changes/phase-1-mvp-control-plane-plan/proposal.md
+++ b/openspec/changes/phase-1-mvp-control-plane-plan/proposal.md
@@ -1,0 +1,54 @@
+# Phase 1 MVP 控制面方案
+
+## 为什么做
+
+当前 `blog-Docs`、`blog-FE`、`blog-BE` 与原始 PRD 之间存在范围和进度错位：
+
+- 原始 PRD 包含评论、富文本、图片上传、全文搜索、reCAPTCHA 等能力。
+- 当前 FE/BE 实际更接近“账号认证 + 文章读写”的最小闭环。
+- 当前 `docs/runtime/phase-current.md` 仍偏模板状态，不能稳定指导阶段推进。
+- 当前 `docs/control-plane/mvp-scope.md` 中仍包含评论等未落地能力，容易让 Agent 抓错 Phase 1 真源。
+- FE/BE 的真实完成度、mock 残留、契约差异尚未被清晰回写到控制面。
+
+因此需要先用 OpenSpec 统筹并冻结 Phase 1 MVP 控制面方案。这个变更不直接执行所有后续修改，而是确定后续文档仓库、前端仓库、后端仓库应该按什么边界、文件职责、验收模型和回写方式继续推进。
+
+## 变更内容
+
+本变更确定 Phase 1 MVP 控制面方案，包括：
+
+- Phase 1 MVP 范围与非目标。
+- 控制面各层文件职责：哪些内容属于 `control-plane`、`runtime`、`harness`、`contracts`、`workflow`、`standards`。
+- 后续 Docs / FE / BE Issue 包拆分方式。
+- Phase 1 验收与证据模型，包括本阶段必要的测试、CI/check 项、smoke 和参考证据。
+- OpenAPI 差异识别要求：先识别 auth/articles 相关差异并形成后续任务，不在本变更中膨胀为完整契约大修。
+
+## 影响范围
+
+- 受影响仓库：`blog-Docs`
+- 下游仓库：`blog-FE`、`blog-BE`
+- 受影响控制面层：
+  - `docs/control-plane/`
+  - `docs/runtime/`
+  - `docs/harness/`
+  - `contracts/api/openapi.yaml`
+  - `docs/workflow/`
+  - `docs/standards/`
+
+## 范围外
+
+- 不直接修改 FE/BE 业务代码。
+- 不直接创建或执行 FE/BE Issue。
+- 不在本变更中完成 OpenAPI 契约大修。
+- 不直接实现评论、富文本、图片上传、全文搜索、reCAPTCHA。
+- 不把所有阶段内容塞进一个文档。
+- 不把运行态状态写进高权重固定层文档。
+
+## 验证影响
+
+本变更会确定 Phase 1 的阶段性验收模型。后续 Issue 执行时，至少应能引用：
+
+- FE 最小检查：`bun run build`、`bun run test`
+- BE 最小检查：`go test ./...`、`go vet ./...`、`go build ./...`
+- 认证 smoke：验证码、注册、登录、当前用户、受保护入口
+- 文章 smoke：创建、列表、详情、编辑、删除、草稿/发布可见性
+- 契约证据：涉及 API 行为时引用 `contracts/api/openapi.yaml` 的对应路径或记录契约差异

--- a/openspec/changes/phase-1-mvp-control-plane-plan/specs/phase-1-mvp-control-plane-plan/spec.md
+++ b/openspec/changes/phase-1-mvp-control-plane-plan/specs/phase-1-mvp-control-plane-plan/spec.md
@@ -1,0 +1,136 @@
+# phase-1-mvp-control-plane-plan 能力规范
+
+## 目的
+
+定义 Phase 1 MVP 控制面方案，使 `blog-Docs` 能准确指导后续 Docs / FE / BE Issue 下发、验收和回写。
+
+## ADDED Requirements
+
+### Requirement: Phase 1 范围必须明确
+
+Phase 1 MUST 被定义为“账号认证 + 文章读写持久化”的最小博客闭环。
+
+#### Scenario: Agent 读取 Phase 1 范围
+
+- **GIVEN** Agent 接到 Phase 1 任务
+- **WHEN** 它读取控制面范围文档
+- **THEN** 它必须知道本阶段包含邮箱验证码注册/登录、JWT 鉴权、文章创建、文章编辑、文章删除、文章发布、文章列表、文章详情和 PostgreSQL 持久化
+- **AND** 它必须知道评论、富文本、图片上传、全文搜索、reCAPTCHA 不属于 Phase 1
+
+#### Scenario: Agent 遇到范围外能力
+
+- **GIVEN** Agent 在 Phase 1 任务中遇到评论、富文本、图片上传、全文搜索或 reCAPTCHA
+- **WHEN** 该能力没有被 PM 通过 OpenSpec 重新纳入 Phase 1
+- **THEN** Agent 必须停止把该能力作为本阶段实现目标
+- **AND** Agent 必须把它记录为后续阶段或范围变更问题
+
+### Requirement: 控制面文件必须各司其职
+
+Phase 1 控制面方案 MUST 把阶段边界、当前状态、验收证据、API 契约、流程规则和接入标准分配到不同层级文件中。
+
+#### Scenario: Agent 查找阶段边界
+
+- **GIVEN** Agent 需要判断 Phase 1 做什么和不做什么
+- **WHEN** 它读取控制面真源
+- **THEN** 它必须被指向 `docs/control-plane/mvp-scope.md` 和 `docs/control-plane/phase-roadmap.md`
+- **AND** 不应从 `docs/runtime/issue-dispatch.md` 推断长期范围边界
+
+#### Scenario: Agent 查找当前阶段状态
+
+- **GIVEN** Agent 需要判断当前 Phase 1 状态、任务入口或风险
+- **WHEN** 它读取运行态真源
+- **THEN** 它必须被指向 `docs/runtime/phase-current.md`、`docs/runtime/issue-dispatch.md` 和 `docs/runtime/risk-register.md`
+- **AND** 不应把 `docs/control-plane/mvp-scope.md` 当作实际完成度证明
+
+#### Scenario: Agent 查找阶段验收要求
+
+- **GIVEN** Agent 需要判断 Phase 1 任务需要跑哪些测试、CI/check 和 smoke
+- **WHEN** 它读取验收真源
+- **THEN** 它必须被指向 `docs/harness/phase-1-mvp-harness.md`
+- **AND** 不应把验收细则塞进 `docs/runtime/phase-current.md`
+
+### Requirement: 后续能力必须有阶段归属
+
+Phase 1 之外的能力 MUST 在阶段路线图中有明确归属，避免被 Agent 随机拉回当前阶段。
+
+#### Scenario: 原始 PRD 包含评论
+
+- **GIVEN** 原始 PRD 包含评论能力
+- **WHEN** Phase 1 范围被评估
+- **THEN** 评论必须在 `docs/control-plane/phase-roadmap.md` 中被标记为后续阶段能力，除非 PM 通过 OpenSpec 将其重新纳入 Phase 1
+
+#### Scenario: 原始 PRD 包含富文本、图片上传、全文搜索和 reCAPTCHA
+
+- **GIVEN** 原始 PRD 包含富文本、图片上传、全文搜索和 reCAPTCHA
+- **WHEN** Phase 1 范围被评估
+- **THEN** 这些能力必须在阶段路线图中被标记为后续阶段能力
+- **AND** 不得作为 Phase 1 MVP 完成判定
+
+### Requirement: Runtime 必须暴露当前项目真实状态
+
+运行层 MUST 记录当前阶段状态、任务入口、风险和 auth/articles 契约差异，避免 mock 残留或契约差异被误判为完成。
+
+#### Scenario: FE 页面仍依赖 mock 数据
+
+- **GIVEN** FE 某个 Phase 1 核心链路仍依赖 mock 数据或 localStorage 假数据
+- **WHEN** 该风险影响 Phase 1 验收
+- **THEN** 它必须被记录到 `docs/runtime/risk-register.md`
+- **AND** 不得作为 Phase 1 完成证据
+
+#### Scenario: BE 能力已实现但缺少契约对齐
+
+- **GIVEN** BE 某个 auth 或 articles 能力已有实现
+- **WHEN** OpenAPI 尚未准确覆盖其请求、响应、错误码或状态语义
+- **THEN** `docs/runtime/openapi-gap-register.md` 必须记录对应 gap
+- **AND** `issue-dispatch.md` 必须能承接后续契约对齐任务
+
+### Requirement: Phase 1 Harness 必须按阶段定义
+
+Phase 1 MUST 有独立的阶段验收文档，定义本阶段必要测试、CI/check、smoke 和证据，不与其他阶段混写。
+
+#### Scenario: FE PR 声称完成 Phase 1 认证或文章任务
+
+- **GIVEN** FE PR 声称完成 Phase 1 认证或文章任务
+- **WHEN** Reviewer 验收该 PR
+- **THEN** PR 必须提供 `bun run build` 和 `bun run test` 的结果
+- **AND** 必须提供与该任务相关的 smoke 证据
+- **AND** 必须说明核心验收是否仍依赖 mock
+
+#### Scenario: BE PR 声称完成 Phase 1 认证或文章任务
+
+- **GIVEN** BE PR 声称完成 Phase 1 认证或文章任务
+- **WHEN** Reviewer 验收该 PR
+- **THEN** PR 必须提供 `go test ./...`、`go vet ./...`、`go build ./...` 的结果
+- **AND** 必须提供与该任务相关的 smoke 或测试证据
+- **AND** 涉及 API 行为时必须引用 OpenAPI 路径或记录 OpenAPI gap
+
+### Requirement: Issue 下发必须支持 Docs / FE / BE 三仓库
+
+运行层 Issue 清单 MUST 支持先规划任务包，再回写真实 GitHub Issue 和 PR 链接。
+
+#### Scenario: 后续 Issue 尚未创建
+
+- **GIVEN** Phase 1 控制面方案已识别一个后续任务包
+- **WHEN** 该任务尚未创建 GitHub Issue
+- **THEN** `docs/runtime/issue-dispatch.md` 可以把它记录为 `planned`
+- **AND** 创建 Issue 后必须回写 URL、状态和真源引用
+
+#### Scenario: Issue 完成后需要回写
+
+- **GIVEN** Docs、FE 或 BE 的 Phase 1 Issue 完成
+- **WHEN** PR 合并或任务被判定完成
+- **THEN** 必须回写 `docs/runtime/issue-dispatch.md`
+- **AND** 如影响风险，必须回写 `docs/runtime/risk-register.md`
+
+## 边界
+
+- 范围内：Phase 1 控制面方案、文件职责、Issue 包规划、阶段验收模型、OpenAPI 差异识别要求。
+- 范围外：FE/BE 代码实现、完整 OpenAPI 大修、评论/富文本/图片上传/全文搜索/reCAPTCHA 实现。
+
+## 参考
+
+- 当前 MVP 范围：`docs/control-plane/mvp-scope.md`
+- 当前阶段：`docs/runtime/phase-current.md`
+- API 契约：`contracts/api/openapi.yaml`
+- 任务发布：`docs/workflow/task-release-and-sync-sop.md`
+- 进度回写：`docs/workflow/progress-sync-protocol.md`

--- a/openspec/changes/phase-1-mvp-control-plane-plan/tasks.md
+++ b/openspec/changes/phase-1-mvp-control-plane-plan/tasks.md
@@ -1,0 +1,39 @@
+# Tasks
+
+## 1. 确认 Phase 1 范围
+
+- [ ] 1.1 确认 Phase 1 命名为 `MVP 最小内容闭环`
+- [ ] 1.2 确认 Phase 1 只包含账号认证、文章读写、文章持久化、游客浏览
+- [ ] 1.3 确认评论、富文本、图片上传、全文搜索、reCAPTCHA 等能力延后
+- [ ] 1.4 确认 Phase 1 完成判定面向真实 API 和真实数据库，不以 mock 作为核心验收证据
+
+## 2. 确认控制面文件职责
+
+- [ ] 2.1 确认 `docs/control-plane/phase-roadmap.md` 负责阶段路线图
+- [ ] 2.2 确认 `docs/control-plane/mvp-scope.md` 负责 Phase 1 范围冻结
+- [ ] 2.3 确认 `docs/runtime/phase-current.md` 负责当前阶段摘要和真源引用
+- [ ] 2.4 确认 `docs/runtime/issue-dispatch.md` 负责 Docs/FE/BE Issue 下发和状态回写
+- [ ] 2.5 确认 `docs/runtime/risk-register.md` 负责当前阶段风险
+- [ ] 2.6 确认 `docs/runtime/openapi-gap-register.md` 负责 auth/articles 契约差异入口
+- [ ] 2.7 确认 `docs/harness/phase-1-mvp-harness.md` 负责阶段性测试、CI/check、smoke 和证据要求
+
+## 3. 确认后续 Issue 包
+
+- [ ] 3.1 确认 Docs Issue 包：范围冻结、runtime 面板、harness、OpenAPI 差异识别、入口引用收口
+- [ ] 3.2 确认 FE Issue 包：认证验收、文章去 mock、AGENTS 接入控制面
+- [ ] 3.3 确认 BE Issue 包：认证验收、文章验收、最小 harness/check
+- [ ] 3.4 确认每个 Issue 必须包含真源引用、验收标准、验证命令和回写目标
+
+## 4. 确认 Phase 1 证据模型
+
+- [ ] 4.1 确认 FE 最小检查为 `bun run build` 和 `bun run test`
+- [ ] 4.2 确认 BE 最小检查为 `go test ./...`、`go vet ./...`、`go build ./...`
+- [ ] 4.3 确认认证 smoke 至少覆盖验证码、注册、登录、当前用户、受保护入口
+- [ ] 4.4 确认文章 smoke 至少覆盖创建、列表、详情、编辑、删除、草稿/发布可见性
+- [ ] 4.5 确认 API 行为差异必须记录为 OpenAPI gap，并拆为后续任务处理
+
+## 5. 评审
+
+- [ ] 5.1 与 PM 评审本方案
+- [ ] 5.2 根据评审意见修订 proposal / design / spec / tasks
+- [ ] 5.3 方案确认后，再拆分后续 Docs / FE / BE Issue


### PR DESCRIPTION
## 决策上下文

这是 Phase 1 MVP 控制面对齐的 stacked PR 入口，只新增 OpenSpec 方案，不修改正式控制面文档。

## 变更摘要

- 新增 `openspec/changes/phase-1-mvp-control-plane-plan/`
- 冻结本轮文档仓库对齐方案：范围、文件职责、Issue 拆分、验收模型、OpenAPI gap 识别边界

## Stacked PR

- Base: `main`
- Head: `docs/p1-openspec-plan`
- 后续 PR 以本 PR 分支为 base

## Harness

- `openspec validate phase-1-mvp-control-plane-plan`：PASS

备注：OpenSpec 命令可能出现 PostHog 遥测网络 flush 报错，不影响 `valid` 结论。
