### PR TITLE
docs(runtime): align phase 1 operating state

### DIFF
--- a/docs/runtime/issue-dispatch.md
+++ b/docs/runtime/issue-dispatch.md
@@ -10,8 +10,11 @@
 
 | Priority | Repo | Issue | Why now | Status |
 |----------|------|-------|---------|--------|
-| P0 | blog-BE | [BqLee-AI/blog-BE#39](https://github.com/BqLee-AI/blog-BE/issues/39) | 违反 fe-be-adoption-gate 第 3 条门禁，AGENTS.md 缺失 | ready |
-| P0 | blog-FE | # | | blocked |
+| P0 | blog-Docs | [BqLee-AI/blog-Docs#44](https://github.com/BqLee-AI/blog-Docs/issues/44) | 需先冻结 Phase Roadmap 与 MVP Scope，避免阶段边界反复变动 | verify |
+| P0 | blog-Docs | [BqLee-AI/blog-Docs#48](https://github.com/BqLee-AI/blog-Docs/issues/48) | 需把 Phase 1 当前运行态从模板落成可执行面板，作为并行协作入口 | verify |
+| P0 | blog-Docs | [BqLee-AI/blog-Docs#47](https://github.com/BqLee-AI/blog-Docs/issues/47) | 需建立 Phase 1 Harness 与验收标准，统一验证口径 | verify |
+| P1 | blog-Docs | [BqLee-AI/blog-Docs#46](https://github.com/BqLee-AI/blog-Docs/issues/46) | 需识别 auth/articles OpenAPI 差异，避免 FE/BE 与契约偏移积累 | verify |
+| P1 | blog-Docs | [BqLee-AI/blog-Docs#45](https://github.com/BqLee-AI/blog-Docs/issues/45) | 需对齐文档仓库入口与引用关系，降低 Agent 取错真源风险 | verify |
 
 字段说明：
 

--- a/docs/runtime/phase-current.md
+++ b/docs/runtime/phase-current.md
@@ -4,35 +4,39 @@
 
 ## 阶段标识
 
-- 阶段名称：
-- 阶段编号（可选）：
-- 状态：planning / active / verifying / done
+- 阶段名称：Phase 1 - MVP 最小内容闭环
+- 阶段编号（可选）：P1
+- 状态：active
 
 ## 本阶段目标（1-3 条）
 
-1.
-2.
-3.
+1. 交付“账号认证 + 文章读写”的最小可用闭环（注册/登录 + 文章创建/编辑/发布 + 游客浏览已发布内容）。
+2. 统一控制面运行态：阶段状态、任务下发、风险处置可在 `docs/runtime/` 持续回写。
+3. 对齐契约与实现：先识别并收敛 auth/articles OpenAPI 差异，避免验证口径漂移。
 
 ## 本阶段非目标（明确不做）
 
--
+- 评论/回复/点赞
+- 富文本编辑器、图片上传、全文搜索、reCAPTCHA
+- 复杂个人中心、复杂后台统计、完整 CI/CD 与 E2E 自动化
 
 ## 本阶段 DoD（完成判定）
 
-- [ ]
-- [ ]
-- [ ]
+- [ ] 认证链路可验收：验证码注册、登录、当前用户与受保护入口行为可复现。
+- [ ] 文章链路可验收：创建、列表、详情、编辑、删除、草稿/发布可见性可复现。
+- [ ] FE 核心验收不依赖 mock，且 auth/articles 契约差异已形成清单并进入跟踪。
 
 ## 本阶段 Harness 验收重点
 
-- 工程秩序（Build/Test/Typecheck）：
-- 契约验证（API/数据语义）：
-- 关键链路 Smoke：
+- 工程秩序（Build/Test/Typecheck）：按 Phase 1 harness 要求执行 FE/BE 最小检查。
+- 契约验证（API/数据语义）：以 `contracts/api/openapi.yaml` 为唯一 API 真源，差异先记录后收敛。
+- 关键链路 Smoke：认证与文章两条主链路必须提供可复现证据。
 
 ## 规则真源引用
 
-- Scope/边界：`docs/control-plane/`
+- Scope/边界：`docs/control-plane/mvp-scope.md`
+- 阶段路线：`docs/control-plane/phase-roadmap.md`
+- 变更依据：`openspec/changes/phase-1-mvp-control-plane-plan/{proposal,design}.md`
 - 流程/SOP：`docs/workflow/`
 - 验证基线：`docs/harness/`
 - 标准规范：`docs/standards/`

--- a/docs/runtime/risk-register.md
+++ b/docs/runtime/risk-register.md
@@ -12,7 +12,9 @@
 
 | Level | Risk | Impact | Owner | Mitigation | Trigger | Status |
 |-------|------|--------|-------|------------|---------|--------|
-| P0 | | | | | | open |
+| P0 | Phase 1 范围漂移（把评论/上传/搜索等 Phase 2+ 能力拉回当前迭代） | 直接稀释认证与文章主链路交付，导致 Phase 1 无法按时闭环 | Docs Owner / PM | 以 OpenSpec Phase 1 口径与 `mvp-scope` 作为下发真源；超界需求转入后续 Issue 并标记 deferred | 任一 P1 Issue/PR 新增评论、上传、搜索、reCAPTCHA 等能力实现或验收项 | mitigating |
+| P1 | FE 核心链路存在 mock 残留 | 验收通过但线上不可用，回归与排障成本升高 | FE Owner | 在 Phase 1 harness 中把去 mock 作为硬门禁；提交证据需包含真实 API 返回与端到端页面行为 | 验收证据无法给出真实请求/响应，或发现页面关键路径仍使用本地 mock 数据 | open |
+| P1 | Auth/Articles OpenAPI 差异持续累积 | FE/BE 集成反复返工，测试用例与契约基线失配 | BE Owner / API Owner | 按 Issue #46 建立差异清单并逐项回写处理状态；以 `contracts/api/openapi.yaml` 为唯一契约真源 | 新增/变更接口在 FE 调用、BE 返回、OpenAPI 三者中出现任一不一致且未登记 | open |
 
 字段说明：
 


### PR DESCRIPTION
## 决策上下文

落实 DOCS-P1-002，只调整 Phase 1 runtime 运行态。

## 变更摘要

- 更新 `docs/runtime/phase-current.md`
- 更新 `docs/runtime/issue-dispatch.md`
- 更新 `docs/runtime/risk-register.md`
- 仅记录 blog-Docs 本轮 Issue，不下发 FE/BE Issue

## Stacked PR

- Base: `docs/p1-control-plane`
- Head: `docs/p1-runtime`
- 前置 PR：Phase Roadmap 与 MVP Scope

## 关联 Issue

Closes #48

## Harness

- `openspec validate phase-1-mvp-control-plane-plan`：PASS
