### PR TITLE
docs(entrypoints): 对齐 Agent 治理入口

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@
 - `docs/control-plane`: 为什么这样治理
 - `docs/workflow`: 怎么推进任务和同步进度
 - `docs/harness`: 怎么做验证闭环
-- `docs/standards`: 怎么写与维护 AGENTS/Rules
+- `docs/standards`: 怎么写与维护 Agent 规范、命名、模板、落点和接入门禁
 - `docs/runtime`: 项目运行态信息（阶段推进、下发清单、当期 DoD、风险台账）
 - `templates/`: 可直接复用的模板
 
@@ -42,6 +42,8 @@
 - Prompt 层：任务目标、范围、验收标准必须明确
 - Context 层：只加载高权重且最新材料，避免历史污染
 - Harness 层：每次任务必须留下可验证证据
+- 默认语言：Issue、PR、文档正文默认中文；路径、命令、API 字段、operationId、包名、分支名保留英文。
+- 标题格式：Issue/PR/commit 标题必须描述结果，优先使用 `type(scope): 中文结果描述`，不得使用 `update docs`、`fix stuff` 等泛化标题。
 
 ## 5) 变更准入规则
 
@@ -50,6 +52,8 @@
 - 每个模板变更要包含：至少一个使用示例
 - PR 必须按 Issue 或职责边界原子化；不得用一个大 PR 同时承载多个可独立评审的控制面任务。
 - 如果多个 PR 存在依赖关系，优先使用 stacked PR，并在 PR 描述中写明 base/head 与前置依赖。
+- Issue / PR / Spec / Harness 必须优先使用 `templates/` 下的对应模板，并在正文保留工作流入口、真源、验收和回写字段。
+- 实际 Issue / PR 正文不得保留 `# Issue 模板`、`# PR 模板` 等模板标题。
 
 文档淘汰与迁移规则：
 
@@ -77,3 +81,13 @@
 - 有可验证检查项（不是主观描述）
 - 有关联对象（FE/BE Issue 或 PR）
 - 有回写入口（进度同步文档）
+
+## 8) Standards 快速入口
+
+- Agent 工作规范：`docs/standards/agent-working-standard.md`
+- 命名规范：`docs/standards/naming-standard.md`
+- 文档落点规范：`docs/standards/document-placement-standard.md`
+- 模板编写规范：`docs/standards/template-authoring-standard.md`
+- AGENTS 编写标准：`docs/standards/agents-md-standard.md`
+- Spec 编写标准：`docs/standards/spec-writing-standard.md`
+- FE/BE 接入门禁：`docs/standards/fe-be-adoption-gate.md`

--- a/README.md
+++ b/README.md
@@ -63,9 +63,14 @@ AI 帮忙收成决策 → 冻结到 spec / 契约
 │   │   ├── harness-closed-loop.md     # Harness 四步闭环
 │   │   ├── harness-gate-baseline.md   # 合并门禁 + 发版门禁
 │   │   └── phase-1-mvp-harness.md     # Phase 1 验收口径
-│   ├── standards/                     ← 标准：怎么写 AGENTS / 仓库怎么接入
+│   ├── standards/                     ← 标准：Agent 怎么工作、命名、落点、模板、接入门禁
+│   │   ├── agent-working-standard.md
 │   │   ├── agents-md-standard.md
-│   │   └── fe-be-adoption-gate.md
+│   │   ├── document-placement-standard.md
+│   │   ├── fe-be-adoption-gate.md
+│   │   ├── naming-standard.md
+│   │   ├── spec-writing-standard.md
+│   │   └── template-authoring-standard.md
 │   └── runtime/                       ← 运行态：当前阶段、Issue 下发、风险台账（可高频更新）
 │       ├── README.md
 │       ├── phase-current.md           # 当前阶段定义
@@ -126,3 +131,14 @@ AI 帮忙收成决策 → 冻结到 spec / 契约
 4. 需要验收口径时读取 `docs/harness/phase-1-mvp-harness.md`
 5. 需要契约差异入口时读取 `docs/runtime/openapi-gap-register.md`
 6. 范围变化先走 OpenSpec，再改固定层文档
+
+## Agent 与模板入口
+
+- Agent 工作规范：`docs/standards/agent-working-standard.md`
+- 命名规范：`docs/standards/naming-standard.md`
+- 文档落点规范：`docs/standards/document-placement-standard.md`
+- 模板编写规范：`docs/standards/template-authoring-standard.md`
+- Issue 模板：`templates/issue-template.md`
+- PR 模板：`templates/pr-template.md`
+- Spec 模板：`templates/spec-template.md`
+- Harness 清单：`templates/harness-checklist.md`

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -20,10 +20,11 @@ context: |
   - Harness layer: require verifiable evidence before merge or release.
 
   Repository structure:
-  - docs/01-control-plane: governance and stable scope/boundary rules
-  - docs/02-workflow: issue/spec/release/sync SOPs
-  - docs/03-harness: validation and orchestration loop
-  - docs/04-standards: writing and agent standards
+  - docs/control-plane: governance and stable scope/boundary rules
+  - docs/workflow: issue/spec/release/sync SOPs
+  - docs/harness: validation and orchestration loop
+  - docs/standards: writing, agent, naming, template, and adoption standards
+  - docs/runtime: current phase status, issue dispatch, risks, and gap registers
   - templates/: reusable execution templates
 
   Stable engineering rules:


### PR DESCRIPTION
## 模板与工作流参考
- 本 PR 模板来源：`templates/pr-template.md`
- 关联 Issue 应符合：`templates/issue-template.md`
- 验收证据应符合：`templates/harness-checklist.md`
- Agent 工作规范：`docs/standards/agent-working-standard.md`
- 命名与标题规范：`docs/standards/naming-standard.md`
- 回写落点规范：`docs/standards/document-placement-standard.md`

## 决策上下文
- 为什么做：`AGENTS.md` 和 `README.md` 需要指向新的 standards/templates 入口，否则 Agent 仍可能跳过或读错上下文。
- 为什么是现在：OpenSpec、standards、templates 已准备好，需要把入口层对齐到新结构。
- 明确不做：不把 standards 全文复制进 AGENTS，不新增阶段任务，不修改 MVP scope。

## 变更摘要
- `AGENTS.md` 增加默认中文、命名、模板使用、实际正文不得保留模板标题等高频硬规则。
- `README.md` 更新 standards 目录结构和 Agent/模板入口。
- `openspec/config.yaml` 修正旧目录名，避免 Agent 被旧路径误导。

## 关联真源
- Issue: Closes #63
- Spec: `openspec/changes/standardize-agent-governance-surfaces/specs/agent-governance-surfaces/spec.md`
- Contract/Rule: `docs/standards/agent-working-standard.md`、`docs/standards/document-placement-standard.md`
- 验收标准在：Issue #63 DoD

## 发布标签
- Level: `l1-openspec`
- Freeze: `freeze:change-request`
- Status: `status:blocked`

## 原子 PR 边界
- 本 PR 只解决：`AGENTS.md`、`README.md`、`openspec/config.yaml` 入口。
- 明确不包含：OpenSpec change、standards、templates。
- 如有前置/后续 PR：依赖 #62/#64 对应 PR，因为入口会引用新增 standards 和模板结构。

## 冻结边界检查
- [x] 只修改授权范围内文件
- [x] 未引入范围外功能
- [x] 未破坏既定契约
- [x] 不涉及契约变更

## 内容验证
- 变更文件在正确分层目录内：仓库入口与 OpenSpec config
- 路径引用有效（无断链）：依赖 #62/#64 合并后成立
- L0/L1 规则变更已经充分讨论确认影响面（如适用）：通过 #61 OpenSpec 承接
- 新增 Spec 包含 Purpose/Requirements/Scenario/Boundaries/References（如适用）：不适用

## Harness 证据
- 检查项：OpenSpec 校验和入口检查
- 命令或人工步骤：在组合分支执行 `openspec validate standardize-agent-governance-surfaces`
- 结果：PASS
- 证据位置：本地命令输出；PostHog telemetry DNS 报错不影响 validate 结果

## 风险与回滚
- 风险：若 #62/#64 未先合并，README/AGENTS 中的新入口会暂时指向未落地文件。
- 回滚：回退本 PR 中 `AGENTS.md`、`README.md`、`openspec/config.yaml` 的修改。

## 回写
- [x] 已更新必要文档（规则/模板/同步记录）
- [ ] 如涉及 Issue 下发，归档前统一回写到 `docs/runtime/issue-dispatch.md`
- [ ] 如涉及风险变化，按需回写到 `docs/runtime/risk-register.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **文档**
  - 优化文档目录结构，补充标准规范快速入口清单
  - 扩展标准文档索引，新增Agent工作、命名、模板编写等标准文档说明
  - 更新模板使用约束与内容格式规范要求

<!-- end of auto-generated comment: release notes by coderabbit.ai -->