### PR TITLE
docs(openspec): 定义 Agent governance surfaces

### DIFF
--- a/openspec/changes/standardize-agent-governance-surfaces/design.md
+++ b/openspec/changes/standardize-agent-governance-surfaces/design.md
@@ -1,0 +1,64 @@
+# 设计说明
+
+## 设计目标
+
+这次变更的目标不是增加更多文档，而是把 Agent 最容易漏读、误写、误判的规则放到正确位置：
+
+- `AGENTS.md`：短、硬、高频，Agent 开工即读。
+- `docs/standards/`：可复用的长期标准，解释规则背后的判断方法。
+- `templates/`：可直接复制使用的执行表单，不承载长篇解释。
+- `docs/runtime/`：阶段状态、Issue 派发、风险和回写记录。
+- `docs/control-plane/`：长期范围、阶段边界、治理红线。
+
+## 分层策略
+
+### `AGENTS.md`
+
+只放 Agent 不读就容易犯错的硬规则：
+
+- 默认语言和标题风格。
+- 必读顺序。
+- 原子 Issue / PR 规则。
+- OpenSpec 触发条件。
+- 验收证据和回写要求。
+- 禁止把临时状态写入固定层。
+
+### `docs/standards/`
+
+放完整标准和判断口径：
+
+- `agent-working-standard.md`：Agent 接任务、判断层级、执行、验收、回写。
+- `naming-standard.md`：Issue / PR / commit / branch / OpenSpec change 命名。
+- `document-placement-standard.md`：内容应该放到哪个目录，什么不需要记录。
+- `template-authoring-standard.md`：模板字段、语言、路径引用、可填写性。
+- 既有 `agents-md-standard.md`、`spec-writing-standard.md`、`fe-be-adoption-gate.md` 继续保留并对齐这些标准。
+
+### `templates/`
+
+模板只解决“提交时怎么填”，不复制 standards 全文。所有模板必须显式列出工作流参考路径，使外部协作者或新 Agent 能从 Issue / PR 自己找到控制面上下文。
+
+## 命名与语言策略
+
+- 文档正文、Issue 正文、PR 正文默认中文。
+- 路径、命令、API 字段、operationId、包名、分支名保留英文。
+- 标题可使用英文 Conventional Commit type/scope，但冒号后的摘要优先中文。
+- commit / PR / Issue 标题应描述结果，不使用 `update docs`、`fix stuff`、`bootstrap ...` 这类泛化描述。
+
+## 迁移与回滚
+
+迁移方式：
+
+- 新增 standards 文件，避免把所有规则塞进 `AGENTS.md`。
+- 优化模板字段，使实际 PR 不再保留“PR 模板”这类模板标题。
+- README / AGENTS 只更新入口和硬规则引用。
+
+回滚方式：
+
+- 如果某个模板字段过重，可单独回退该模板文件。
+- 如果某条标准产生冲突，以 `docs/control-plane/control-plane-handbook.md` 与已接受 OpenSpec 为裁决依据。
+
+## 风险
+
+- 模板过长导致 Agent 继续跳读：通过“模板只放表单，解释放 standards”控制。
+- 规则重复导致冲突：通过 `document-placement-standard.md` 定义落点，避免同一规则多处展开。
+- 命名规范过度约束：保留中文摘要和技术英文标识共存，优先可读与可追踪。

--- a/openspec/changes/standardize-agent-governance-surfaces/proposal.md
+++ b/openspec/changes/standardize-agent-governance-surfaces/proposal.md
@@ -1,0 +1,60 @@
+# 统一 Agent-facing Governance Surfaces
+
+## 为什么做
+
+当前 `docs/standards/` 与 `templates/` 已能提供基本入口，但还不足以稳定约束 AI Agent 的日常行为：
+
+- `AGENTS.md` 与标准文档之间的职责边界不够清楚，Agent 容易跳过长文档或把临时状态写进固定层。
+- Issue / PR / Spec / Harness 模板缺少显式工作流入口，新协作者或 Agent 不一定知道应该参考哪些路径。
+- Issue、PR、commit、branch、OpenSpec change 的命名风格不统一，容易出现中英混杂、标题泛化、重复前缀等问题。
+- `docs/standards/` 的部分文档偏原则化，不足以回答“这条规则应该放在哪里、什么不需要记录、如何验收”。
+
+因此需要用一个独立 OpenSpec change 统一 Agent 可直接接触到的治理表面：`AGENTS.md`、`docs/standards/`、`templates/`、README 入口和最小验证方式。
+
+## 变更内容
+
+本变更将：
+
+- 明确哪些硬规则必须固化到 `AGENTS.md`，哪些长期标准归入 `docs/standards/`，哪些运行态信息归入 `docs/runtime/`，哪些内容不应记录。
+- 建立 Agent 工作规范、命名规范、文档落点规范、模板编写规范。
+- 优化 Issue / PR / Spec / Harness 模板，使其显式声明模板来源、上游真源、验收入口和回写入口。
+- 统一默认语言和标题风格：正文默认中文，技术标识、命令、路径、API 字段保留英文。
+- 对齐 README 与 AGENTS 的入口说明，确保 Agent 不需要猜测工作流上下文。
+
+## 影响范围
+
+- 受影响仓库：`blog-Docs`
+- 受影响文件层：
+  - `AGENTS.md`
+  - `README.md`
+  - `docs/standards/`
+  - `templates/`
+  - `openspec/changes/standardize-agent-governance-surfaces/`
+
+## 范围外
+
+- 不修改 Phase 1 MVP scope。
+- 不修改 `docs/control-plane/mvp-scope.md` 或 `docs/control-plane/phase-roadmap.md`。
+- 不执行 OpenAPI 契约大修。
+- 不直接同步模板到 `blog-FE` 或 `blog-BE`。
+- 不改 FE/BE 业务代码。
+- 不把历史聊天、临时想法、一次性命令输出沉淀为稳定规则。
+
+## 验证影响
+
+本变更完成后，后续 Issue / PR 应能直接引用：
+
+- Agent 工作规范：`docs/standards/agent-working-standard.md`
+- 命名规范：`docs/standards/naming-standard.md`
+- 文档落点规范：`docs/standards/document-placement-standard.md`
+- 模板编写规范：`docs/standards/template-authoring-standard.md`
+- Issue 模板：`templates/issue-template.md`
+- PR 模板：`templates/pr-template.md`
+- Spec 模板：`templates/spec-template.md`
+- Harness 清单：`templates/harness-checklist.md`
+
+验收时应执行：
+
+- `openspec validate standardize-agent-governance-surfaces`
+- 人工检查模板正文是否包含工作流入口、真源、范围、验收和回写字段
+- 人工检查 README / AGENTS 是否只承载高频硬规则，不重复 standards 全文

--- a/openspec/changes/standardize-agent-governance-surfaces/specs/agent-governance-surfaces/spec.md
+++ b/openspec/changes/standardize-agent-governance-surfaces/specs/agent-governance-surfaces/spec.md
@@ -1,0 +1,109 @@
+# agent-governance-surfaces 能力规范
+
+## 目的
+
+定义 Agent-facing governance surfaces 的职责边界和最低内容要求，使 AI Agent 与人类协作者在接 Issue、开 PR、写 Spec、验收和回写时能从同一套入口执行任务。
+
+## ADDED Requirements
+
+### Requirement: Agent 入口必须短路径可执行
+
+`AGENTS.md` MUST 只承载 Agent 开工必须立即遵守的高频硬规则，并指向更完整的 standards 文档。
+
+#### Scenario: Agent 接到文档仓库任务
+
+- **GIVEN** Agent 接到 `blog-Docs` 任务
+- **WHEN** 它读取 `AGENTS.md`
+- **THEN** 它必须能知道默认语言、读取顺序、OpenSpec 触发条件、原子 PR 规则、验收证据要求和回写要求
+- **AND** 它必须能找到 `docs/standards/` 中的完整规范入口
+
+#### Scenario: 标准规则过长
+
+- **GIVEN** 某条规则需要较长解释、示例或判断分支
+- **WHEN** 该规则不是 Agent 每次开工必须立即记住的硬约束
+- **THEN** 它必须写入 `docs/standards/`
+- **AND** `AGENTS.md` 只保留一句短规则和路径引用
+
+### Requirement: 文档落点必须可判断
+
+控制面 MUST 定义内容落点规则，说明什么写入 `AGENTS.md`、`docs/control-plane/`、`docs/runtime/`、`docs/harness/`、`docs/standards/`、`templates/`，以及什么不需要记录。
+
+#### Scenario: Agent 准备记录一条信息
+
+- **GIVEN** Agent 准备把一条信息写入文档仓库
+- **WHEN** 它无法判断落点
+- **THEN** 它必须参考 `docs/standards/document-placement-standard.md`
+- **AND** 不得把临时状态写入固定层文档
+
+#### Scenario: 信息没有复用价值
+
+- **GIVEN** 某条信息只是临时聊天过程、一次性命令输出或已被 git diff 完整表达的琐碎说明
+- **WHEN** 它没有形成决策、验收证据、风险或可复用规则
+- **THEN** 它不应被写入稳定文档
+
+### Requirement: 模板必须自带工作流入口
+
+Issue、PR、Spec 和 Harness 模板 MUST 显式声明模板来源、上游真源、验收入口和回写入口。
+
+#### Scenario: 新 Agent 只拿到一个 Issue
+
+- **GIVEN** 新 Agent 没有完整工作流上下文
+- **WHEN** 它读取 Issue 正文
+- **THEN** 它必须能看到 Issue 模板参考路径、PR 模板参考路径、Harness 清单、Agent 工作规范和文档落点规范
+- **AND** 它必须能按这些路径继续加载上下文
+
+#### Scenario: Reviewer 只打开一个 PR
+
+- **GIVEN** Reviewer 只打开 PR 页面
+- **WHEN** 它检查 PR 描述
+- **THEN** 它必须能看到关联 Issue、Spec、Contract/Rule、验收标准和回写目标
+- **AND** 它必须能判断该 PR 是否符合原子化边界
+
+### Requirement: 命名必须统一且可追踪
+
+Issue、PR、commit、branch、OpenSpec change 的命名 MUST 遵循统一规则，正文默认中文，技术标识保留英文。
+
+#### Scenario: Agent 创建 PR 或 commit
+
+- **GIVEN** Agent 准备创建 PR 或 commit
+- **WHEN** 它编写标题
+- **THEN** 标题应使用 `type(scope): 中文结果描述` 格式
+- **AND** 不应使用 `update docs`、`fix stuff`、`bootstrap workspace` 等泛化标题
+
+#### Scenario: Agent 创建 OpenSpec change
+
+- **GIVEN** Agent 准备创建 OpenSpec change
+- **WHEN** 它命名 change id
+- **THEN** change id 必须使用 kebab-case 英文短语
+- **AND** proposal/design/tasks/spec 正文默认中文
+
+### Requirement: Standards 与 Templates 不得重复膨胀
+
+Standards MUST 定义判断规则，Templates MUST 提供可填写字段。模板不得复制 standards 全文，standards 不得伪装成执行表单。
+
+#### Scenario: 模板需要解释规则
+
+- **GIVEN** 模板字段背后有复杂判断
+- **WHEN** 该解释超过简短提示
+- **THEN** 模板必须引用对应 standard
+- **AND** 不得在模板内复制长篇规则正文
+
+#### Scenario: 标准需要执行入口
+
+- **GIVEN** 某个 standard 规定了 Issue 或 PR 必填字段
+- **WHEN** Agent 需要实际提交
+- **THEN** standard 必须指向对应模板
+- **AND** 模板必须能独立填写并提交
+
+## 边界
+
+- 范围内：Agent 工作规范、命名规范、文档落点规范、模板编写规范、Issue/PR/Spec/Harness 模板、README/AGENTS 入口。
+- 范围外：Phase 1 MVP 范围、OpenAPI 契约大修、FE/BE 代码实现、FE/BE 模板同步落地。
+
+## 参考
+
+- Agent 入口：`AGENTS.md`
+- 标准目录：`docs/standards/`
+- 模板目录：`templates/`
+- 控制面主真源：`docs/control-plane/control-plane-handbook.md`
+- 当前模板：`templates/issue-template.md`、`templates/pr-template.md`、`templates/spec-template.md`、`templates/harness-checklist.md`

--- a/openspec/changes/standardize-agent-governance-surfaces/tasks.md
+++ b/openspec/changes/standardize-agent-governance-surfaces/tasks.md
@@ -1,0 +1,36 @@
+# 任务清单
+
+## 1. OpenSpec
+
+- [x] 输入：现有 `AGENTS.md`、`docs/standards/`、`templates/`、README。
+- [x] 输出：`openspec/changes/standardize-agent-governance-surfaces/`。
+- [x] 验收：`openspec validate standardize-agent-governance-surfaces` 通过。
+- [ ] 回写：本 change 归档前更新相关 runtime 状态。
+
+## 2. Standards
+
+- [x] 输入：`docs/standards/agents-md-standard.md`、`fe-be-adoption-gate.md`、`spec-writing-standard.md`。
+- [x] 输出：新增或更新 Agent 工作、命名、文档落点、模板编写、Spec 写作、FE/BE 接入标准。
+- [x] 验收：每个标准都说明目的、适用范围、必做规则、禁止事项、验收检查。
+- [x] 回写：README 目录结构包含新增标准。
+
+## 3. Templates
+
+- [x] 输入：`templates/issue-template.md`、`pr-template.md`、`spec-template.md`、`harness-checklist.md`。
+- [x] 输出：模板显式包含工作流入口、真源、范围、验收、回写字段。
+- [x] 验收：模板可直接复制到 Issue / PR 使用，不保留“模板标题”作为实际正文。
+- [x] 回写：`docs/standards/template-authoring-standard.md` 描述模板字段规则。
+
+## 4. Entrypoints
+
+- [x] 输入：`AGENTS.md`、`README.md`。
+- [x] 输出：入口说明只保留高频硬规则和路径索引。
+- [x] 验收：AGENTS 不重复 standards 全文；README 目录结构与实际文件一致。
+- [x] 回写：如发现新的长期硬约束，回写到 `AGENTS.md` 或对应 standard。
+
+## 5. Validation
+
+- [x] 执行 `openspec validate standardize-agent-governance-surfaces`。
+- [x] 执行路径检查，确认新增/引用文件存在。
+- [x] 检查模板默认中文、技术标识保留英文。
+- [x] 检查没有修改 Phase 1 MVP scope、OpenAPI 契约或 FE/BE 仓库文件。


### PR DESCRIPTION
## 模板与工作流参考
- 本 PR 模板来源：`templates/pr-template.md`
- 关联 Issue 应符合：`templates/issue-template.md`
- 验收证据应符合：`templates/harness-checklist.md`
- Agent 工作规范：`docs/standards/agent-working-standard.md`
- 命名与标题规范：`docs/standards/naming-standard.md`
- 回写落点规范：`docs/standards/document-placement-standard.md`

## 决策上下文
- 为什么做：需要先用 OpenSpec 冻结 Agent-facing governance surfaces 的职责边界，避免后续 standards、templates、AGENTS 入口各自扩散。
- 为什么是现在：Phase 1 控制面已完成归档，本轮进入模板与 standards 优化，需要先确定变更范围。
- 明确不做：不修改 MVP scope，不改 OpenAPI 契约，不同步 FE/BE 仓库模板，不改业务代码。

## 变更摘要
- 新增 `standardize-agent-governance-surfaces` OpenSpec change。
- 定义 AGENTS、standards、templates、runtime、control-plane 的职责分层。
- 明确模板必须自带工作流入口、命名默认中文、技术标识保留英文。

## 关联真源
- Issue: Closes #61
- Spec: `openspec/changes/standardize-agent-governance-surfaces/specs/agent-governance-surfaces/spec.md`
- Contract/Rule: `docs/control-plane/control-plane-handbook.md`
- 验收标准在：本 PR OpenSpec tasks 与 Issue #61 DoD

## 发布标签
- Level: `l1-openspec`
- Freeze: `freeze:change-request`
- Status: `status:ready`

## 原子 PR 边界
- 本 PR 只解决：新增 OpenSpec change。
- 明确不包含：standards 正文、templates 正文、AGENTS/README 入口改动。
- 如有前置/后续 PR：后续 #62/#64/#63 对应 PR 基于本 change 执行。

## 冻结边界检查
- [x] 只修改授权范围内文件
- [x] 未引入范围外功能
- [x] 未破坏既定契约
- [x] 不涉及契约变更

## 内容验证
- 变更文件在正确分层目录内：`openspec/changes/standardize-agent-governance-surfaces/`
- 路径引用有效（无断链）：引用路径为后续 PR 将落地的标准/模板入口
- L0/L1 规则变更已经充分讨论确认影响面（如适用）：已通过本 OpenSpec change 表达
- 新增 Spec 包含 Purpose/Requirements/Scenario/Boundaries/References（如适用）：是

## Harness 证据
- 检查项：OpenSpec 校验
- 命令或人工步骤：`openspec validate standardize-agent-governance-surfaces`
- 结果：PASS
- 证据位置：本地命令输出；PostHog telemetry DNS 报错不影响 validate 结果

## 风险与回滚
- 风险：后续 PR 若不按该 change 拆分，仍可能形成模板与 standards 重复。
- 回滚：回退本 PR 新增的 `openspec/changes/standardize-agent-governance-surfaces/` 目录。

## 回写
- [x] 已更新必要文档（规则/模板/同步记录）
- [ ] 如涉及 Issue 下发，归档前统一回写到 `docs/runtime/issue-dispatch.md`
- [ ] 如涉及风险变化，按需回写到 `docs/runtime/risk-register.md`
