### PR TITLE
docs(templates): 优化治理模板入口

### DIFF
--- a/templates/harness-checklist.md
+++ b/templates/harness-checklist.md
@@ -1,18 +1,36 @@
-# Harness 验证清单
+## Evidence References
+- Harness 清单来源：`templates/harness-checklist.md`
+- Agent 工作规范：`docs/standards/agent-working-standard.md`
+- 模板编写规范：`docs/standards/template-authoring-standard.md`
+- 验收标准来源：
+- 关联 Issue：
+- 关联 PR：
+- 回写目标：
 
 ## 通用
 - [ ] 关联 Issue 与 Spec 完整
 - [ ] 变更范围符合约束
+- [ ] PR 符合原子边界
 - [ ] 验证失败时有阻断结论
 
 ## BE
 - [ ] `go build ./...` 通过
 - [ ] `go test ./...` 通过（如适用）
+- [ ] `go vet ./...` 通过（如适用）
 - [ ] 核心接口 smoke 通过（如适用）
+- [ ] 涉及 API 行为时已引用 OpenAPI 路径或记录 gap
 
 ## FE
 - [ ] `bun run build` 通过
+- [ ] `bun run test` 通过（如适用）
 - [ ] 关键页面可访问（如适用）
+- [ ] 核心路径不依赖 mock，或已明确标记 mock 风险
+
+## 证据四要素
+- 检查项：
+- 命令或人工步骤：
+- 结果：
+- 证据位置：
 
 ## 回写
 - [ ] PR 描述包含验证证据

--- a/templates/issue-template.md
+++ b/templates/issue-template.md
@@ -1,4 +1,11 @@
-# Issue 模板
+## 工作流入口
+- Issue 模板参考：`templates/issue-template.md`
+- PR 模板参考：`templates/pr-template.md`
+- Harness 清单参考：`templates/harness-checklist.md`
+- Spec 模板参考：`templates/spec-template.md`
+- Agent 工作规范：`docs/standards/agent-working-standard.md`
+- 命名规范：`docs/standards/naming-standard.md`
+- 文档落点规范：`docs/standards/document-placement-standard.md`
 
 ## 决策上下文
 - 为什么做：
@@ -9,13 +16,14 @@
 - Spec:
 - Contract/Rule:
 - OpenSpec change（如适用）:
+- Runtime 状态（如适用）:
 
 ## 变更分级
 - [ ] L0 可直接执行（不扩边界、不改契约）
 - [ ] L1 需要 OpenSpec（新功能/契约变更/跨仓库依赖）
 - [ ] L2 BLOCKER（边界冲突/安全风险/P0 阻塞）
 
-## 实现约束
+## 授权范围
 - 只允许修改：
 - 禁止修改：
 - 依赖前置条件：
@@ -26,10 +34,16 @@
 - [ ]
 
 ## Harness
-- 验证命令：
+- 验证命令或人工步骤：
 - 证据形式：
+- 失败时阻断结论：
+
+## 回写目标
+- Runtime 回写：
+- 风险回写：
+- 经验/规则回写：
 
 ## 关联
-- Issue:
+- 上游 Issue:
 - 上游依赖:
 - 相关 PR:

--- a/templates/pr-template.md
+++ b/templates/pr-template.md
@@ -1,4 +1,10 @@
-# PR 模板
+## 模板与工作流参考
+- 本 PR 模板来源：`templates/pr-template.md`
+- 关联 Issue 应符合：`templates/issue-template.md`
+- 验收证据应符合：`templates/harness-checklist.md`
+- Agent 工作规范：`docs/standards/agent-working-standard.md`
+- 命名与标题规范：`docs/standards/naming-standard.md`
+- 回写落点规范：`docs/standards/document-placement-standard.md`
 
 ## 决策上下文
 - 为什么做：
@@ -18,6 +24,11 @@
 - Freeze: `freeze:locked` / `freeze:change-request`
 - Status: `status:ready` / `status:blocked` / `status:deferred`
 
+## 原子 PR 边界
+- 本 PR 只解决：
+- 明确不包含：
+- 如有前置/后续 PR：
+
 ## 冻结边界检查
 - [ ] 只修改授权范围内文件
 - [ ] 未引入范围外功能
@@ -30,6 +41,12 @@
 - L0/L1 规则变更已经充分讨论确认影响面（如适用）：
 - 新增 Spec 包含 Purpose/Requirements/Scenario/Boundaries/References（如适用）：
 
+## Harness 证据
+- 检查项：
+- 命令或人工步骤：
+- 结果：
+- 证据位置：
+
 ## 风险与回滚
 - 风险:
 - 回滚:
@@ -37,3 +54,4 @@
 ## 回写
 - [ ] 已更新必要文档（规则/模板/同步记录）
 - [ ] 如涉及 Issue 下发，已回写到 `docs/runtime/issue-dispatch.md`
+- [ ] 如涉及风险变化，已回写到 `docs/runtime/risk-register.md`

--- a/templates/spec-template.md
+++ b/templates/spec-template.md
@@ -1,4 +1,8 @@
-# Spec 模板
+## Authoring References
+- Spec 写作标准：`docs/standards/spec-writing-standard.md`
+- 模板编写规范：`docs/standards/template-authoring-standard.md`
+- 文档落点规范：`docs/standards/document-placement-standard.md`
+- OpenSpec change 目录：`openspec/changes/<change-id>/`
 
 ## Purpose
 一段话说明这个 spec 管什么、不管什么。
@@ -9,6 +13,7 @@
 <要求描述，使用 MUST/SHALL/MUST NOT 语义>
 
 #### Scenario: <场景名>
+
 - **GIVEN** <前置条件>
 - **WHEN** <触发动作>
 - **THEN** <期望结果>
@@ -21,3 +26,8 @@
 - 上游 spec:
 - 受影响仓库:
 - 契约文件: contracts/openapi.yaml#<operationId>
+
+## Verification
+- 验收方式：
+- 证据位置：
+- 回写目标：


### PR DESCRIPTION
## 模板与工作流参考
- 本 PR 模板来源：`templates/pr-template.md`
- 关联 Issue 应符合：`templates/issue-template.md`
- 验收证据应符合：`templates/harness-checklist.md`
- Agent 工作规范：`docs/standards/agent-working-standard.md`
- 命名与标题规范：`docs/standards/naming-standard.md`
- 回写落点规范：`docs/standards/document-placement-standard.md`

## 决策上下文
- 为什么做：Issue/PR/Spec/Harness 模板需要自带工作流入口，方便不了解上下文的人或 Agent 直接接入。
- 为什么是现在：standards 已定义后，模板可以引用标准路径而不是复制长篇规则。
- 明确不做：不改 standards 正文，不改 AGENTS/README，不写阶段状态。

## 变更摘要
- Issue 模板增加工作流入口、Runtime 状态、授权范围、回写目标。
- PR 模板增加模板参考、原子 PR 边界、Harness 证据和风险回写。
- Spec 模板增加 Authoring References 和 Verification。
- Harness 清单增加证据四要素、mock 风险、OpenAPI gap 说明。

## 关联真源
- Issue: Closes #64
- Spec: `openspec/changes/standardize-agent-governance-surfaces/specs/agent-governance-surfaces/spec.md`
- Contract/Rule: `docs/standards/template-authoring-standard.md`
- 验收标准在：Issue #64 DoD

## 发布标签
- Level: `l1-openspec`
- Freeze: `freeze:change-request`
- Status: `status:blocked`

## 原子 PR 边界
- 本 PR 只解决：`templates/` 模板正文。
- 明确不包含：OpenSpec change、standards、AGENTS/README。
- 如有前置/后续 PR：依赖 #62 对应 standards PR，因为模板引用新增 standards 路径。

## 冻结边界检查
- [x] 只修改授权范围内文件
- [x] 未引入范围外功能
- [x] 未破坏既定契约
- [x] 不涉及契约变更

## 内容验证
- 变更文件在正确分层目录内：`templates/`
- 路径引用有效（无断链）：依赖 #62 合并后成立
- L0/L1 规则变更已经充分讨论确认影响面（如适用）：通过 #61 OpenSpec 承接
- 新增 Spec 包含 Purpose/Requirements/Scenario/Boundaries/References（如适用）：不适用

## Harness 证据
- 检查项：模板字段检查
- 命令或人工步骤：确认模板包含工作流入口、真源、范围、验收、回写字段；扫描无 `# PR 模板` / `# Issue 模板` 标题
- 结果：PASS
- 证据位置：PR diff；本地 `rg -n "^# PR 模板$|^# Issue 模板$" templates ...` 无命中

## 风险与回滚
- 风险：若 #62 未先合并，模板中的部分 standards 路径在 main 上暂时不存在。
- 回滚：回退本 PR 中 `templates/` 的修改。

## 回写
- [x] 已更新必要文档（规则/模板/同步记录）
- [ ] 如涉及 Issue 下发，归档前统一回写到 `docs/runtime/issue-dispatch.md`
- [ ] 如涉及风险变化，按需回写到 `docs/runtime/risk-register.md`
